### PR TITLE
fix: prevent the installer from starting solr

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -87,6 +87,9 @@ if [ -f #{node['solr']['install']}/solr/bin/solr ]; then
   fi
 fi
 
+# Flag we just installed solr
+echo 'solr-installed' > /tmp/solr-installed
+
 #{node['solr']['download']}/solr-#{node['solr']['version']}/bin/install_solr_service.sh \
   #{node['solr']['download']}/solr-#{node['solr']['version']}.tgz \
   -d #{node['solr']['directory']} \
@@ -111,6 +114,13 @@ end
 link "#{node['solr']['install']}/solr/bin/solr.in.sh" do
   owner node['solr']['user']
   to '/etc/default/solr.in.sh'
+end
+
+# delete the flag that solr was just installed
+file '/tmp/solr-installed' do
+  action :delete
+  only_if { ::File.exist?('/tmp/solr-installed') }
+  notifies :stop, 'service[solr]', :immediately
 end
 
 service 'solr' do


### PR DESCRIPTION
`-n` was added to the installer here https://github.com/apache/lucene-solr/blob/branch_6x/solr/bin/install_solr_service.sh#L51

However in 5.x you cant prevent solr from starting the service